### PR TITLE
docs(regex): update to regex to match scope with hyphens and quote

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ filters:
     - Merge branch
 categories:
   - title: 'Features'
-    regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?feat(\([\w'-]+\))??!?:.+$'
     weight: 10
   - title: 'Fixes'
-    regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?fix(\([\w'-]+\))??!?:.+$'
     weight: 20
   - title: 'Documentation'
-    regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?docs(\([\w'-]+\))??!?:.+$'
     weight: 30
   - title: Others
     weight: 9999


### PR DESCRIPTION
# Summary

Update the regex suggested in the documentation to let commit scopes allow hyphens and quotes. 

![image](https://github.com/releaseros/releaseros/assets/37048906/5bddccb5-7d1d-4bc5-a5b1-e67dd6ab1626)
