### PR TITLE
fix(config): default config should allowed to sort commit with scope containing a hyphen

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,13 @@ filters:
     - Merge branch
 categories:
   - title: 'Features'
-    regexp: '^.*?feat(\([\w'-]+\))??!?:.+$'
+    regexp: '^.*?feat(\([[:word:]-]+\))??!?:.+$'
     weight: 10
   - title: 'Fixes'
-    regexp: '^.*?fix(\([\w'-]+\))??!?:.+$'
+    regexp: '^.*?fix(\([[:word:]-]+\))??!?:.+$'
     weight: 20
   - title: 'Documentation'
-    regexp: '^.*?docs(\([\w'-]+\))??!?:.+$'
+    regexp: '^.*?docs(\([[:word:]-]+\))??!?:.+$'
     weight: 30
   - title: Others
     weight: 9999

--- a/command/generate_test.go
+++ b/command/generate_test.go
@@ -64,6 +64,7 @@ func TestGenerate(t *stdtesting.T) {
 	testing.GitCommit(t, "feat: does it work? maybe. will I check? no")
 	testing.GitCommit(t, "chore: don't ask me")
 	testing.GitCommit(t, "test: I cannot believe that it took this long to write a test for this")
+	testing.GitCommit(t, "feat(check-in): LOTS of changes. period")
 
 	testing.GitAnnotatedTag(t, "v1.1.0", "second release")
 
@@ -72,6 +73,7 @@ func TestGenerate(t *stdtesting.T) {
 
 ### Features
 
+\* ([a-z0-9]){7} feat\(check\-in\): LOTS of changes. period
 \* ([a-z0-9]){7} feat: commit 2
 \* ([a-z0-9]){7} feat: does it work\? maybe\. will I check\? no
 \* ([a-z0-9]){7} feat: what happens in vegas stays in vegas

--- a/internal/config/config.yaml
+++ b/internal/config/config.yaml
@@ -1,4 +1,4 @@
-initial_release_message: | 
+initial_release_message: |
   Initial Release
 sort: asc
 filters:
@@ -11,13 +11,13 @@ filters:
     - Merge branch
 categories:
   - title: 'Features'
-    regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?feat(\([[:word:]-]+\))??!?:.+$'
     weight: 10
   - title: 'Fixes'
-    regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?fix(\([[:word:]-]+\))??!?:.+$'
     weight: 20
   - title: 'Documentation'
-    regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?docs(\([[:word:]-]+\))??!?:.+$'
     weight: 30
   - title: Others
     weight: 9999

--- a/internal/config/default_test.go
+++ b/internal/config/default_test.go
@@ -40,17 +40,17 @@ func TestDefaultConfigIsLoadable(t *testing.T) {
 			Categories: []Category{
 				{
 					Title:  "Features",
-					Regexp: `^.*?feat(\([[:word:]]+\))??!?:.+$`,
+					Regexp: `^.*?feat(\([[:word:]-]+\))??!?:.+$`,
 					Weight: 10,
 				},
 				{
 					Title:  "Fixes",
-					Regexp: `^.*?fix(\([[:word:]]+\))??!?:.+$`,
+					Regexp: `^.*?fix(\([[:word:]-]+\))??!?:.+$`,
 					Weight: 20,
 				},
 				{
 					Title:  "Documentation",
-					Regexp: `^.*?docs(\([[:word:]]+\))??!?:.+$`,
+					Regexp: `^.*?docs(\([[:word:]-]+\))??!?:.+$`,
 					Weight: 30,
 				},
 				{

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -55,13 +55,13 @@ filters:
     - Merge branch
 categories:
   - title: 'Features'
-    regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?feat(\([[:word:]-]+\))??!?:.+$'
     weight: 1
   - title: 'Fixes'
-    regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?fix(\([[:word:]-]+\))??!?:.+$'
     weight: 2
   - title: 'Documentation'
-    regexp: ^.*?docs(\([[:word:]]+\))??!?:.+$
+    regexp: ^.*?docs(\([[:word:]-]+\))??!?:.+$
     weight: 3
   - title: Others
     weight: 9999
@@ -126,17 +126,17 @@ func ExpectedConfig() Config {
 		Categories: []Category{
 			{
 				Title:  "Features",
-				Regexp: `^.*?feat(\([[:word:]]+\))??!?:.+$`,
+				Regexp: `^.*?feat(\([[:word:]-]+\))??!?:.+$`,
 				Weight: 1,
 			},
 			{
 				Title:  "Fixes",
-				Regexp: `^.*?fix(\([[:word:]]+\))??!?:.+$`,
+				Regexp: `^.*?fix(\([[:word:]-]+\))??!?:.+$`,
 				Weight: 2,
 			},
 			{
 				Title:  "Documentation",
-				Regexp: `^.*?docs(\([[:word:]]+\))??!?:.+$`,
+				Regexp: `^.*?docs(\([[:word:]-]+\))??!?:.+$`,
 				Weight: 3,
 			},
 			{

--- a/internal/config/testdata/config.yaml
+++ b/internal/config/testdata/config.yaml
@@ -10,13 +10,13 @@ filters:
     - Merge branch
 categories:
   - title: 'Features'
-    regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?feat(\([[:word:]-]+\))??!?:.+$'
     weight: 1
   - title: 'Fixes'
-    regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?fix(\([[:word:]-]+\))??!?:.+$'
     weight: 2
   - title: 'Documentation'
-    regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+    regexp: '^.*?docs(\([[:word:]-]+\))??!?:.+$'
     weight: 3
   - title: Others
     weight: 9999

--- a/internal/releasenote/generate_test.go
+++ b/internal/releasenote/generate_test.go
@@ -152,17 +152,17 @@ func TestGenerate(t *testing.T) {
 				Categories: []config.Category{
 					{
 						Title:  "Features",
-						Regexp: `^.*?feat(\([[:word:]]+\))??!?:.+$`,
+						Regexp: `^.*?feat(\([[:word:]-]+\))??!?:.+$`,
 						Weight: 1,
 					},
 					{
 						Title:  "Fixes",
-						Regexp: `^.*?fix(\([[:word:]]+\))??!?:.+$`,
+						Regexp: `^.*?fix(\([[:word:]-]+\))??!?:.+$`,
 						Weight: 2,
 					},
 					{
 						Title:  "Documentation",
-						Regexp: `^.*?docs(\([[:word:]]+\))??!?:.+$`,
+						Regexp: `^.*?docs(\([[:word:]-]+\))??!?:.+$`,
 						Weight: 3,
 					},
 					{
@@ -373,22 +373,22 @@ func TestGenerate(t *testing.T) {
 				Categories: []config.Category{
 					{
 						Title:  "BREAKING CHANGES / Features",
-						Regexp: `^.*?feat(\([[:word:]]+\))??!+:.+$`,
+						Regexp: `^.*?feat(\([[:word:]-]+\))??!+:.+$`,
 						Weight: 1,
 					},
 					{
 						Title:  "Features",
-						Regexp: `^.*?feat(\([[:word:]]+\))??!{0}:.+$`,
+						Regexp: `^.*?feat(\([[:word:]-]+\))??!{0}:.+$`,
 						Weight: 2,
 					},
 					{
 						Title:  "Fixes",
-						Regexp: `^.*?fix(\([[:word:]]+\))??!?:.+$`,
+						Regexp: `^.*?fix(\([[:word:]-]+\))??!?:.+$`,
 						Weight: 3,
 					},
 					{
 						Title:  "Documentation",
-						Regexp: `^.*?docs(\([[:word:]]+\))??!?:.+$`,
+						Regexp: `^.*?docs(\([[:word:]-]+\))??!?:.+$`,
 						Weight: 4,
 					},
 					{


### PR DESCRIPTION


Theoretically (see https://www.conventionalcommits.org/en/v1.0.0/#specification):
```
A scope MAY be provided after a type. A scope MUST consist of a noun describing a section of the codebase surrounded by parenthesis, e.g., fix(parser):
```

Some nouns like compound nouns may have a hyphen.